### PR TITLE
Track whether a given state should result in queue removal

### DIFF
--- a/state-machine-generator/src/main/java/com/github/davidmoten/fsm/model/State.java
+++ b/state-machine-generator/src/main/java/com/github/davidmoten/fsm/model/State.java
@@ -13,12 +13,18 @@ public final class State<T, R extends Event<? super T>> {
     private final Class<R> eventClass;
     private final StateMachineDefinition<T> m;
     private boolean isCreationDestination;
+    private boolean triggerQueueRemoval;
     private Optional<String> documentation = Optional.empty();
 
     public State(StateMachineDefinition<T> m, String name, Class<R> eventClass) {
+        this(m, name, eventClass, false);
+    }
+
+    public State(StateMachineDefinition<T> m, String name, Class<R> eventClass, boolean triggerQueueRemoval) {
         this.m = m;
         this.name = name;
         this.eventClass = eventClass;
+        this.triggerQueueRemoval = triggerQueueRemoval;
     }
 
     public Class<R> eventClass() {
@@ -64,6 +70,16 @@ public final class State<T, R extends Event<? super T>> {
 
     public boolean isInitial() {
         return name().equals("Initial");
+    }
+
+    /**
+     * Some states trigger the removal of commands from the queue even though the state is not
+     * the final state in the state machine. All states that are terminal will also trigger queue
+     * removal.
+     * @return
+     */
+    public boolean triggerQueueRemoval() {
+        return this.isTerminal() || this.triggerQueueRemoval;
     }
 
     public boolean isTerminal() {

--- a/state-machine-generator/src/main/java/com/github/davidmoten/fsm/model/StateMachineDefinition.java
+++ b/state-machine-generator/src/main/java/com/github/davidmoten/fsm/model/StateMachineDefinition.java
@@ -51,16 +51,44 @@ public final class StateMachineDefinition<T> {
         return cls;
     }
 
-    public <R extends Event<? super T>> State<T, R> createState(String name, Class<R> eventClass) {
+    /**
+     * Method for building a State and adding it to this State Machine Definition.
+     * @param name - The name of the state
+     * @param eventClass - The class this event belongs to
+     * @param triggerQueueRemoval - Whether this state triggers removal of the command from queue,
+     *                            regardless of whether it is a terminal state.
+     * @return The created state
+     */
+    public <R extends Event<? super T>> State<T, R> createState(String name, Class<R> eventClass, boolean triggerQueueRemoval) {
         Preconditions.checkArgument(!eventClass.isAnnotationPresent(GenerateImmutable.class),
                 "cannot base a state on an event that is annotated with @GenerateImmutable, use the generated immutable class instead");
         Preconditions.checkNotNull(name);
         if (name.equals("Initial")) {
             name = name.concat("_1");
         }
-        State<T, R> state = new State<T, R>(this, name, eventClass);
+        State<T, R> state = new State<T, R>(this, name, eventClass, triggerQueueRemoval);
         states.add(state);
         return state;
+    }
+
+    /**
+     * Method for building a State and adding it to this State Machine Definition.
+     * @param name - The name of the state
+     * @param eventClass - The class this event belongs to
+     * @return The created state
+     */
+    public <R extends Event<? super T>> State<T, R> createState(String name, Class<R> eventClass) {
+        return this.createState(name, eventClass, false);
+    }
+
+    public boolean triggerQueueRemoval(String stateName) {
+        State state = this.getState(stateName);
+
+        if(state == null) {
+            throw new InvalidStateNameException("Invalid state name: " + stateName);
+        }
+
+        return state.triggerQueueRemoval();
     }
 
     public final State<T, ? extends Event<? super T>> getState(String name) {

--- a/state-machine-generator/src/test/java/com/github/davidmoten/fsm/model/StateMachineTest.java
+++ b/state-machine-generator/src/test/java/com/github/davidmoten/fsm/model/StateMachineTest.java
@@ -41,6 +41,10 @@ public class StateMachineTest {
         assert(stateMachineDefinition.isTerminal("SUCCEEDED"));
         assert(!stateMachineDefinition.isTerminal("DOWNLOAD_SUCCEEDED"));
 
+        assert(stateMachineDefinition.triggerQueueRemoval("DOWNLOAD_SUCCEEDED"));
+        assert(stateMachineDefinition.triggerQueueRemoval("SUCCEEDED"));
+        assert(!stateMachineDefinition.triggerQueueRemoval("STARTED"));
+
         // throws invalid state name exception
         stateMachineDefinition.isReachable("meow", "cookiemonster");
 

--- a/state-machine-generator/src/test/java/com/github/davidmoten/resources/analyzer/StateMachineDefinitions.java
+++ b/state-machine-generator/src/test/java/com/github/davidmoten/resources/analyzer/StateMachineDefinitions.java
@@ -35,7 +35,7 @@ public class StateMachineDefinitions implements Supplier<List<StateMachineDefini
             m.createState("DOWNLOADING", Downloading.class);
 
         State<Execution, DownloadSucceeded> downloadSucceeded =
-            m.createState("DOWNLOAD_SUCCEEDED", DownloadSucceeded.class);
+            m.createState("DOWNLOAD_SUCCEEDED", DownloadSucceeded.class, true);
 
         State<Execution, DownloadTimeout> downloadTimeout =
             m.createState("DOWNLOAD_TIMEOUT", DownloadTimeout.class);


### PR DESCRIPTION
- Some states should trigger queue removal even if they do not represent
  a termination in the command execution. The StateMachineDefinition
  class now supports this.